### PR TITLE
Add digitalocean as a provider for vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,13 +9,13 @@ Vagrant.configure("2") do |config|
   config.vm.network "private_network", ip: "172.16.100.2"
 
   config.vm.provision :ansible do |ansible|
-    ansible.playbook = "site.yml"
+    ansible.playbook = "test.yml"
     ansible.host_key_checking = false
-    ansible.extra_vars = { ansible_ssh_user: "vagrant", testing: true }
+    ansible.extra_vars = { testing: true }
 
     # ansible.tags = ["blog"]
     # ansible.skip_tags = ["openvpn"]
-    # ansible.verbose = "vvvv"
+    ansible.verbose = "vvvv"
   end
 
   config.vm.provider :virtualbox do |v|
@@ -24,6 +24,18 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider :vmware_fusion do |v|
     v.vmx["memsize"] = "256"
+  end
+
+  config.vm.provider :digital_ocean do |provider, override|
+    override.ssh.private_key_path = "~/.ssh/id_rsa"
+    override.vm.box = "digital_ocean"
+    override.vm.box_url = "https://github.com/smdahlen/vagrant-digitalocean/raw/master/box/digital_ocean.box"
+
+    provider.ssh_key_name = "TODO"
+    provider.token = "TODO"
+    provider.image = "debian-7-0-x64"
+    provider.region = "nyc3"
+    provider.size = "512mb"
   end
 
   #

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -6,6 +6,3 @@
 
 - name: restart fail2ban
   service: name=fail2ban state=restarted
-
-- name: restart ssh
-  service: name=ssh state=restarted

--- a/roles/common/tasks/security.yml
+++ b/roles/common/tasks/security.yml
@@ -15,7 +15,3 @@
 
 - name: Ensure fail2ban is started
   service: name=fail2ban state=started
-
-- name: Update sshd config to disallow root logins
-  lineinfile: dest=/etc/ssh/sshd_config regexp=^PermitRootLogin line="PermitRootLogin no" state=present
-  notify: restart ssh

--- a/roles/ssh/README.md
+++ b/roles/ssh/README.md
@@ -1,0 +1,8 @@
+empress.ssh
+===========
+
+Disables ssh `root` login. This improves security, but may get in the way if you
+aren't using a `deploy` user.
+
+Eventually, this should provide a number of common configurable tweaks for ssh,
+like disabling password auth.

--- a/roles/ssh/handlers/main.yml
+++ b/roles/ssh/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: restart ssh
+  service: name=ssh state=restarted

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Update sshd config to disallow root logins
+  lineinfile: dest=/etc/ssh/sshd_config regexp=^PermitRootLogin line="PermitRootLogin no" state=present
+  notify: restart ssh

--- a/site.yml
+++ b/site.yml
@@ -7,10 +7,11 @@
   gather_facts: True
   vars_files:
     - vars/defaults.yml
-    - vars/{{ 'testing' if testing is defined else 'user' }}.yml
+    - vars/user.yml
 
   roles:
     - common
     - mailserver
+    - ssh
     - tarsnap
     # - mailpile # fix this

--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,18 @@
+---
+# Installs all the stuff that makes sense to use together for testing purposes
+# eventually we may want to have multiple implementations of this to test common
+# setups, eg. different vagrant configs for different sql backends.
+
+- hosts: all
+  # user should be defined by vagrant
+  sudo: True
+  gather_facts: True
+  vars_files:
+    - vars/defaults.yml
+    - vars/testing.yml
+
+  roles:
+    - common
+    - mailserver
+    - tarsnap
+    # - mailpile # fix this

--- a/vars/testing.yml
+++ b/vars/testing.yml
@@ -5,6 +5,7 @@
 ###############################################################################
 
 # common
+testing: true
 domain: empress.local
 main_user_name: empress
 timezone: America/Los_Angeles


### PR DESCRIPTION
I've got a slow-ass laptop, so deploying to digitalocean is faster, and cheap enough that I don't care.

This sets some default passwords, which makes the box vulnerable, but the machine is short-lived and has no sensitive information so it shouldn't matter. Long-term, this should be fixed somehow.
